### PR TITLE
Potential fix for code scanning alert no. 3: Flask app is run in debug mode

### DIFF
--- a/backend/src/wsgi.py
+++ b/backend/src/wsgi.py
@@ -1,4 +1,6 @@
 from app import app
+import os
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/ProgrammingLab/www.prolab.club/security/code-scanning/3](https://github.com/ProgrammingLab/www.prolab.club/security/code-scanning/3)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to control the debug mode using an environment variable. This way, we can set the debug mode to `True` during development and `False` during production.

1. Import the `os` module to access environment variables.
2. Use an environment variable to set the `debug` parameter in the `app.run` method.
3. Update the code to read the environment variable and set the `debug` parameter accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
